### PR TITLE
Rollbacked go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/achiku/hseq
 
-go 1.22
+go 1.21


### PR DESCRIPTION
Changed version at go.mod: 1.22 to 1.21

![image](https://github.com/achiku/hseq/assets/289766/09ed193e-8f29-480e-b875-c6a09f2b86fe)
